### PR TITLE
Bug fix: convert チ to 'ci'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "ainconv"
-version = "0.1.0"
+version = "0.1.1"

--- a/src/conversion/katakana.rs
+++ b/src/conversion/katakana.rs
@@ -243,6 +243,7 @@ pub fn convert_kana_to_latn(kana: &str) -> String {
             'セ' => Some("se"),
             'ソ' => Some("so"),
             'タ' => Some("ta"),
+            'チ' => Some("ci"),
             'テ' => Some("te"),
             'ト' => Some("to"),
             'ナ' => Some("na"),

--- a/tests/conversion.rs
+++ b/tests/conversion.rs
@@ -1,9 +1,11 @@
 use ainconv::*;
 
-const TEST_CASES: [(&str, &'static [&str], &str, &str, &str, &str); 14] = [
+const TEST_CASES: [(&str, &'static [&str], &str, &str, &str, &str); 16] = [
     ("", &[], "", "", "", ""),
     ("aynu", &["ay", "nu"], "アイヌ", "айну", "애누", "ainu"),
     ("itak", &["i", "tak"], "イタㇰ", "итак", "이닥", "itak"),
+    ("maciya", &["ma", "ci", "ya"], "マチヤ", "мация" /* TODO: мачия? */, "마지야", "maciya"),
+    ("acapo", &["a", "ca", "po"], "アチャポ", "ацапо" /* TODO: ачапо? */, "아자포", "acapo"),
     ("aynuitak", &["ay", "nu", "i", "tak"], "アイヌイタㇰ", "айнуитак", "애누이닥", "ainuitak"),
     ("sinep", &["si", "nep"], "シネㇷ゚", "синэп", "시넙", "sinep"),
     ("ruunpe", &["ru", "un", "pe"], "ルウンペ", "руунпэ", "루운버", "ruunpe"),


### PR DESCRIPTION
チ was originally only handled for digraphs, and the monograph case was overlooked.