### PR TITLE
fix: character-indexed syllabification (multibyte ’ no longer panics)

### DIFF
--- a/src/conversion/katakana.rs
+++ b/src/conversion/katakana.rs
@@ -123,6 +123,7 @@ pub fn convert_latn_to_kana(latn: &str) -> String {
                 "wo" => "ヲ",
                 "nn" => "ン",
                 "tt" => "ッ",
+                "" => "",
                 _ => syllable,
             };
             result.push_str(converted_remains);
@@ -483,8 +484,8 @@ mod tests {
 
     #[test]
     fn vowelless_input_does_not_panic() {
-        let _ = convert_latn_to_kana("k");
-        let _ = convert_latn_to_kana("n");
-        let _ = convert_latn_to_kana("");
+        assert_eq!(convert_latn_to_kana("k"), "ㇰ");
+        assert_eq!(convert_latn_to_kana("n"), "ン");
+        assert_eq!(convert_latn_to_kana(""), "");
     }
 }

--- a/src/conversion/katakana.rs
+++ b/src/conversion/katakana.rs
@@ -44,8 +44,10 @@ pub fn convert_latn_to_kana(latn: &str) -> String {
             let last_char = syllable.chars().last().unwrap();
 
             let (remains, coda) = if CONSONANTS.contains(last_char) {
-                let (remains, coda) = syllable.split_at(syllable.len() - 1);
-                (remains, coda)
+                // Split off the final consonant at its CHARACTER boundary; a
+                // multi-byte coda (e.g. the glottal stop ’) would make
+                // `len() - 1` slice mid-character and panic.
+                syllable.split_at(syllable.len() - last_char.len_utf8())
             } else {
                 (syllable.as_str(), "")
             };
@@ -464,4 +466,25 @@ pub fn convert_kana_to_latn(kana: &str) -> String {
         })
         .collect::<Vec<String>>()
         .join("")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::convert_latn_to_kana;
+
+    #[test]
+    fn glottal_stop_coda_does_not_panic() {
+        // A syllable ending in the multi-byte glottal stop ’ used to slice
+        // mid-character in `split_at(len - 1)`.
+        assert_eq!(convert_latn_to_kana("ne\u{2019}"), "ネ");
+        assert_eq!(convert_latn_to_kana("po\u{2019}"), "ポ");
+        assert_eq!(convert_latn_to_kana("nispa\u{2019}"), "ニㇱパ");
+    }
+
+    #[test]
+    fn vowelless_input_does_not_panic() {
+        let _ = convert_latn_to_kana("k");
+        let _ = convert_latn_to_kana("n");
+        let _ = convert_latn_to_kana("");
+    }
 }

--- a/src/syllable.rs
+++ b/src/syllable.rs
@@ -14,12 +14,17 @@ use std::collections::HashMap;
 /// println!("{:?}", separated); // ["pro", "gram", "ming", "is", "fun"]
 /// ```
 pub fn separate(latn: &str) -> Vec<String> {
+    // Index by CHARACTER throughout (not byte), so multi-byte characters such as
+    // the glottal stop ’ (U+2019) are handled correctly rather than corrupting the
+    // syllable map (and, downstream, panicking on a non-char-boundary slice).
+    let chars: Vec<char> = latn.chars().collect();
+    let n = chars.len();
     let mut syllable_map: HashMap<usize, usize> = HashMap::new();
     let mut syllable_count = 1;
 
-    for (i, char) in latn.chars().enumerate() {
-        if VOWELS.contains(char) {
-            if i > 0 && CONSONANTS.contains(latn.chars().nth(i - 1).unwrap()) {
+    for i in 0..n {
+        if VOWELS.contains(chars[i]) {
+            if i > 0 && CONSONANTS.contains(chars[i - 1]) {
                 syllable_map.insert(i - 1, syllable_count);
             }
             syllable_map.insert(i, syllable_count);
@@ -27,31 +32,33 @@ pub fn separate(latn: &str) -> Vec<String> {
         }
     }
 
-    // Fill codas
-    for i in 0..latn.len() {
+    // Fill codas: an unassigned character joins the syllable on its left.
+    for i in 0..n {
         if !syllable_map.contains_key(&i) {
-            syllable_map.insert(i, *syllable_map.get(&(i - 1)).unwrap_or(&0));
+            let prev = i
+                .checked_sub(1)
+                .and_then(|p| syllable_map.get(&p))
+                .copied()
+                .unwrap_or(0);
+            syllable_map.insert(i, prev);
         }
     }
 
-    // Group and extract syllables
+    // Group and extract syllables.
     let mut syllables: Vec<String> = Vec::new();
     let mut current_group_id = 1;
     let mut head = 0;
-    let chars: Vec<char> = latn.chars().collect();
-
-    for i in 0..latn.len() {
+    for i in 0..n {
         if *syllable_map.get(&i).unwrap_or(&0) != current_group_id {
             current_group_id = *syllable_map.get(&i).unwrap_or(&0);
             syllables.push(chars[head..i].iter().collect());
             head = i;
         }
     }
-
     syllables.push(chars[head..].iter().collect());
 
-    // Remove apostrophes from syllables
-    syllables.iter().map(|s| s.replace("'", "")).collect()
+    // Remove apostrophes from syllables.
+    syllables.iter().map(|s| s.replace('\'', "")).collect()
 }
 
 #[cfg(test)]
@@ -62,5 +69,20 @@ mod tests {
     fn test_separate() {
         let separated = separate("eyaykosiramsuypa");
         assert_eq!(separated, vec!["e", "yay", "ko", "si", "ram", "suy", "pa"]);
+    }
+
+    #[test]
+    fn separate_handles_glottal_stop() {
+        // The multi-byte glottal stop ’ (U+2019) must be indexed by character;
+        // mixing byte and char indices used to corrupt the map and could panic.
+        assert_eq!(separate("ne\u{2019}"), vec!["ne\u{2019}"]);
+        assert_eq!(separate("a\u{2019}e"), vec!["a", "\u{2019}e"]);
+    }
+
+    #[test]
+    fn separate_bare_consonant_does_not_panic() {
+        // The coda-fill loop computed `i - 1` at `i == 0` (usize underflow).
+        let _ = separate("k");
+        let _ = separate("");
     }
 }


### PR DESCRIPTION
## Bug
`convert_latn_to_kana` **panics** on any word whose syllable ends in the multibyte glottal stop `’` (U+2019) — e.g. `ne’`, `po’`. `convert_word` does `split_at(len - 1)`, which slices mid-character. (This is the root cause of a crash in the ainuKey IME, currently worked around there.)

## Fix — two underlying bugs
1. **`syllable::separate` mixed byte and char indices.** The vowel scan used character indices, but the coda-fill and grouping loops used `latn.len()` (bytes) and indexed the `chars` vec with byte offsets — corrupting the syllable map for any multibyte input and risking an out-of-bounds slice. Now indexed by **character** throughout. The coda-fill also did `i - 1` at `i == 0` (usize underflow → panic on a bare consonant); guarded with `checked_sub`.
2. **`convert_word::split_at`** now splits at the final character's boundary (`len - last_char.len_utf8()`) instead of `len - 1`.

## Tests
`ne’`→ネ, `po’`→ポ, `nispa’`→ニㇱパ, and bare `k`/`n` no longer panic. New regression tests in `separate` and `convert`; **all existing tests pass** (incl. the shared `tests/cases` fixtures).