### PR TITLE
feat: opt-in ellipsis-to-ASCII conversion option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for missing half-width katakana `ﾝ` support.
 - Added support for non-combining modifiers.
 - Added support for hiragana.
+- Added `convert_kana_to_latn_with_options` and a `ConversionOptions` struct with
+  an opt-in `ellipsis_to_ascii` toggle that rewrites `…` (U+2026) to `...`.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,21 @@ println!("{}", convert_cyrl_to_kana("иранкараптэ")); // "イランカ
 println!("{}", convert_kana_to_cyrl("イランカラㇷ゚テ")); // "иранкараптэ"
 ```
 
+#### Conversion Options
+
+When converting from Katakana, some punctuation normalizations are opt-in. By
+default the horizontal ellipsis `…` (U+2026) is kept as-is, since it is the
+semantically correct single character. Pass `ConversionOptions` to rewrite it to
+three ASCII full stops `...`:
+
+```rust
+use ainconv::{convert_kana_to_latn, convert_kana_to_latn_with_options, ConversionOptions};
+
+let opts = ConversionOptions { ellipsis_to_ascii: true };
+println!("{}", convert_kana_to_latn_with_options("…", &opts)); // "..."
+println!("{}", convert_kana_to_latn("…")); // "…" (unchanged)
+```
+
 ### Extra Functionality
 
 #### Script Detection

--- a/src/conversion/katakana.rs
+++ b/src/conversion/katakana.rs
@@ -2,6 +2,7 @@
 use crate::conversion::latin::CONSONANTS;
 use crate::syllable::separate;
 use crate::util::{remove_acute_accent, IsLetter, SplitIntoWords};
+use crate::ConversionOptions;
 use unicode_normalization::UnicodeNormalization;
 
 /// Convert romanized Ainu to Katakana
@@ -212,6 +213,25 @@ pub fn convert_latn_to_kana(latn: &str) -> String {
 /// assert_eq!(latn, "ainu");
 /// ```
 pub fn convert_kana_to_latn(kana: &str) -> String {
+    convert_kana_to_latn_with_options(kana, &ConversionOptions::default())
+}
+
+/// Convert Katakana to romanized Ainu, tweaking punctuation handling via
+/// [`ConversionOptions`].
+///
+/// This behaves exactly like [`convert_kana_to_latn`] but lets the caller opt
+/// into normalizations that are off by default.
+///
+/// # Example
+///
+/// ```
+/// use ainconv::{convert_kana_to_latn, convert_kana_to_latn_with_options, ConversionOptions};
+/// // `…` is kept as-is by default, but can be rewritten to ASCII.
+/// let opts = ConversionOptions { ellipsis_to_ascii: true };
+/// assert_eq!(convert_kana_to_latn_with_options("…", &opts), "...");
+/// assert_eq!(convert_kana_to_latn("…"), "…");
+/// ```
+pub fn convert_kana_to_latn_with_options(kana: &str, options: &ConversionOptions) -> String {
     fn convert_word(word: &str) -> String {
         let mut result: Vec<String> = Vec::new();
         let mut chars = word
@@ -450,6 +470,7 @@ pub fn convert_kana_to_latn(kana: &str) -> String {
                 word.to_owned()
                     .chars()
                     .map(|c| match c {
+                        '…' if options.ellipsis_to_ascii => "...".into(),
                         '。' => ". ".into(),
                         '「' => " \"".into(),
                         '」' => "\" ".into(),
@@ -471,7 +492,32 @@ pub fn convert_kana_to_latn(kana: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::convert_latn_to_kana;
+    use super::{convert_kana_to_latn, convert_kana_to_latn_with_options, convert_latn_to_kana};
+    use crate::ConversionOptions;
+
+    #[test]
+    fn ellipsis_kept_by_default() {
+        assert_eq!(convert_kana_to_latn("…"), "…");
+        assert_eq!(convert_kana_to_latn("アイヌ…"), "ainu…");
+    }
+
+    #[test]
+    fn ellipsis_converted_when_enabled() {
+        let opts = ConversionOptions {
+            ellipsis_to_ascii: true,
+        };
+        assert_eq!(convert_kana_to_latn_with_options("…", &opts), "...");
+        assert_eq!(convert_kana_to_latn_with_options("アイヌ…", &opts), "ainu...");
+    }
+
+    #[test]
+    fn default_options_match_plain_function() {
+        let opts = ConversionOptions::default();
+        assert_eq!(
+            convert_kana_to_latn_with_options("アイヌ…", &opts),
+            convert_kana_to_latn("アイヌ…")
+        );
+    }
 
     #[test]
     fn glottal_stop_coda_does_not_panic() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,24 @@ pub enum Script {
     Unknown,
 }
 
+/// Options that tweak how punctuation is normalized during conversion.
+///
+/// Construct from [`Default`] and override only the toggles you need:
+///
+/// ```
+/// use ainconv::ConversionOptions;
+/// let opts = ConversionOptions { ellipsis_to_ascii: true };
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ConversionOptions {
+    /// When `true`, the horizontal ellipsis `…` (U+2026) is rewritten as three
+    /// ASCII full stops `...`.
+    ///
+    /// Defaults to `false`, leaving `…` intact: it is a single, semantically
+    /// correct character, so the rewrite is opt-in.
+    pub ellipsis_to_ascii: bool,
+}
+
 mod util;
 
 mod conversion {
@@ -31,7 +49,9 @@ mod detection;
 pub use detection::detect;
 
 pub use conversion::cyrillic::{convert_cyrl_to_latn, convert_latn_to_cyrl};
-pub use conversion::katakana::{convert_kana_to_latn, convert_latn_to_kana};
+pub use conversion::katakana::{
+    convert_kana_to_latn, convert_kana_to_latn_with_options, convert_latn_to_kana,
+};
 
 pub fn convert_cyrl_to_kana(cyrl: &str) -> String {
     convert_latn_to_kana(&convert_cyrl_to_latn(cyrl))


### PR DESCRIPTION
## Summary

Implements #5 as an **opt-in toggle** rather than default behavior.

As noted in #5, `…` (U+2026 HORIZONTAL ELLIPSIS) is the semantically correct single character, so converting it to three ASCII full stops `...` should not be the default. This PR adds a small options API so callers can opt in.

- Add public `ConversionOptions { ellipsis_to_ascii: bool }` struct (derives `Default`).
- Add `convert_kana_to_latn_with_options(&str, &ConversionOptions) -> String`.
- `convert_kana_to_latn` now delegates to it with `ConversionOptions::default()`, so existing behavior is unchanged (`…` stays `…`).

```rust
let opts = ConversionOptions { ellipsis_to_ascii: true };
convert_kana_to_latn_with_options("…", &opts); // "..."
convert_kana_to_latn("…");                      // "…" (unchanged)
```

## Tests

`cargo test` — 24 pass (12 unit + 4 integration + 8 doctests). New unit tests cover: ellipsis kept by default, converted when enabled, and default-options equals the plain function.

Docs updated in `README.md` and `CHANGELOG.md`.

Closes #5