### PR TITLE
feat: Katakana variant options for latn→kana + shared parity harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for hiragana.
 - Added `convert_kana_to_latn_with_options` and a `ConversionOptions` struct with
   an opt-in `ellipsis_to_ascii` toggle that rewrites `…` (U+2026) to `...`.
+- Added `convert_latn_to_kana_with_options` with Katakana variant toggles
+  (`use_wi`, `use_we`, `use_wo`, `use_small_i`, `use_small_u`, `use_small_n`) on
+  `ConversionOptions`, matching the option set of the Python implementation.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,20 @@ three ASCII full stops `...`:
 ```rust
 use ainconv::{convert_kana_to_latn, convert_kana_to_latn_with_options, ConversionOptions};
 
-let opts = ConversionOptions { ellipsis_to_ascii: true };
+let opts = ConversionOptions { ellipsis_to_ascii: true, ..Default::default() };
 println!("{}", convert_kana_to_latn_with_options("…", &opts)); // "..."
 println!("{}", convert_kana_to_latn("…")); // "…" (unchanged)
+```
+
+`convert_latn_to_kana_with_options` likewise selects compact Katakana variant
+forms that are otherwise spelled out by default:
+
+```rust
+use ainconv::{convert_latn_to_kana, convert_latn_to_kana_with_options, ConversionOptions};
+
+let opts = ConversionOptions { use_wi: true, ..Default::default() };
+println!("{}", convert_latn_to_kana_with_options("wina", &opts)); // "ヰナ"
+println!("{}", convert_latn_to_kana("wina")); // "ウィナ"
 ```
 
 ### Extra Functionality

--- a/src/conversion/katakana.rs
+++ b/src/conversion/katakana.rs
@@ -23,7 +23,26 @@ use unicode_normalization::UnicodeNormalization;
 /// assert_eq!(kana, "アイヌ");
 /// ```
 pub fn convert_latn_to_kana(latn: &str) -> String {
-    fn convert_word(word: &str) -> String {
+    convert_latn_to_kana_with_options(latn, &ConversionOptions::default())
+}
+
+/// Convert romanized Ainu to Katakana, selecting Katakana variant forms via
+/// [`ConversionOptions`].
+///
+/// This behaves exactly like [`convert_latn_to_kana`] but lets the caller keep
+/// the compact variant kana (`ヰ`/`ヱ`/`ヲ`, small `ィ`/`ゥ`, `ㇴ`) that are
+/// otherwise spelled out by default.
+///
+/// # Example
+///
+/// ```
+/// use ainconv::{convert_latn_to_kana, convert_latn_to_kana_with_options, ConversionOptions};
+/// let opts = ConversionOptions { use_wi: true, ..Default::default() };
+/// assert_eq!(convert_latn_to_kana_with_options("wina", &opts), "ヰナ");
+/// assert_eq!(convert_latn_to_kana("wina"), "ウィナ");
+/// ```
+pub fn convert_latn_to_kana_with_options(latn: &str, options: &ConversionOptions) -> String {
+    fn convert_word(word: &str, options: &ConversionOptions) -> String {
         let latn = word.replace("=", "");
         let latn = remove_acute_accent(&latn);
         let latn = latn.to_ascii_lowercase();
@@ -172,21 +191,35 @@ pub fn convert_latn_to_kana(latn: &str) -> String {
             result.push_str(converted_coda);
         }
 
-        result
-            .replace('ィ', "イ")
-            .replace('ゥ', "ウ")
-            .replace("ㇴ", "ン")
-            .replace("ヱ", "ウェ")
-            .replace("ヰ", "ウィ")
-            .replace("ヲ", "ウォ")
-            .replace("’", "")
+        // Spell out the compact variant kana unless the caller opted to keep
+        // them. Each replacement targets a disjoint character, so order does
+        // not matter.
+        if !options.use_small_i {
+            result = result.replace('ィ', "イ");
+        }
+        if !options.use_small_u {
+            result = result.replace('ゥ', "ウ");
+        }
+        if !options.use_small_n {
+            result = result.replace('ㇴ', "ン");
+        }
+        if !options.use_wi {
+            result = result.replace('ヰ', "ウィ");
+        }
+        if !options.use_we {
+            result = result.replace('ヱ', "ウェ");
+        }
+        if !options.use_wo {
+            result = result.replace('ヲ', "ウォ");
+        }
+        result.replace('’', "")
     }
 
     latn.split_into_words()
         .into_iter()
         .map(|word| {
             if word.chars().all(|c| c.is_ainu_letter()) {
-                convert_word(&word)
+                convert_word(&word, options)
             } else {
                 word.to_owned()
             }
@@ -227,7 +260,7 @@ pub fn convert_kana_to_latn(kana: &str) -> String {
 /// ```
 /// use ainconv::{convert_kana_to_latn, convert_kana_to_latn_with_options, ConversionOptions};
 /// // `…` is kept as-is by default, but can be rewritten to ASCII.
-/// let opts = ConversionOptions { ellipsis_to_ascii: true };
+/// let opts = ConversionOptions { ellipsis_to_ascii: true, ..Default::default() };
 /// assert_eq!(convert_kana_to_latn_with_options("…", &opts), "...");
 /// assert_eq!(convert_kana_to_latn("…"), "…");
 /// ```
@@ -505,6 +538,7 @@ mod tests {
     fn ellipsis_converted_when_enabled() {
         let opts = ConversionOptions {
             ellipsis_to_ascii: true,
+            ..Default::default()
         };
         assert_eq!(convert_kana_to_latn_with_options("…", &opts), "...");
         assert_eq!(convert_kana_to_latn_with_options("アイヌ…", &opts), "ainu...");
@@ -517,6 +551,43 @@ mod tests {
             convert_kana_to_latn_with_options("アイヌ…", &opts),
             convert_kana_to_latn("アイヌ…")
         );
+    }
+
+    #[test]
+    fn katakana_variants_spelled_out_by_default() {
+        assert_eq!(convert_latn_to_kana("wina"), "ウィナ");
+        assert_eq!(convert_latn_to_kana("wen"), "ウェン");
+        assert_eq!(convert_latn_to_kana("kay"), "カイ");
+        assert_eq!(convert_latn_to_kana("kew"), "ケウ");
+        assert_eq!(convert_latn_to_kana("mun"), "ムン");
+    }
+
+    #[test]
+    fn katakana_variants_kept_when_enabled() {
+        use crate::convert_latn_to_kana_with_options;
+        let wi = ConversionOptions {
+            use_wi: true,
+            ..Default::default()
+        };
+        assert_eq!(convert_latn_to_kana_with_options("wina", &wi), "ヰナ");
+
+        let small_i = ConversionOptions {
+            use_small_i: true,
+            ..Default::default()
+        };
+        assert_eq!(convert_latn_to_kana_with_options("kay", &small_i), "カィ");
+
+        let small_u = ConversionOptions {
+            use_small_u: true,
+            ..Default::default()
+        };
+        assert_eq!(convert_latn_to_kana_with_options("kew", &small_u), "ケゥ");
+
+        let small_n = ConversionOptions {
+            use_small_n: true,
+            ..Default::default()
+        };
+        assert_eq!(convert_latn_to_kana_with_options("mun", &small_n), "ムㇴ");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,16 +21,40 @@ pub enum Script {
 ///
 /// ```
 /// use ainconv::ConversionOptions;
-/// let opts = ConversionOptions { ellipsis_to_ascii: true };
+/// let opts = ConversionOptions { ellipsis_to_ascii: true, ..Default::default() };
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ConversionOptions {
     /// When `true`, the horizontal ellipsis `…` (U+2026) is rewritten as three
-    /// ASCII full stops `...`.
+    /// ASCII full stops `...` during Katakana → Latin conversion.
     ///
     /// Defaults to `false`, leaving `…` intact: it is a single, semantically
     /// correct character, so the rewrite is opt-in.
     pub ellipsis_to_ascii: bool,
+
+    /// When `true`, Latin → Katakana keeps `ヰ` (wi) instead of spelling it out
+    /// as `ウィ`, e.g. `wina` → `ヰナ` instead of `ウィナ`. Defaults to `false`.
+    pub use_wi: bool,
+
+    /// When `true`, Latin → Katakana keeps `ヱ` (we) instead of spelling it out
+    /// as `ウェ`, e.g. `weni` → `ヱニ` instead of `ウェニ`. Defaults to `false`.
+    pub use_we: bool,
+
+    /// When `true`, Latin → Katakana keeps `ヲ` (wo) instead of spelling it out
+    /// as `ウォ`. Defaults to `false`.
+    pub use_wo: bool,
+
+    /// When `true`, Latin → Katakana keeps the small `ィ` for the `-y` coda
+    /// instead of `イ`, e.g. `kay` → `カィ` instead of `カイ`. Defaults to `false`.
+    pub use_small_i: bool,
+
+    /// When `true`, Latin → Katakana keeps the small `ゥ` for the `-w` coda
+    /// instead of `ウ`, e.g. `kew` → `ケゥ` instead of `ケウ`. Defaults to `false`.
+    pub use_small_u: bool,
+
+    /// When `true`, Latin → Katakana keeps `ㇴ` for the `-n` coda instead of `ン`,
+    /// e.g. `mun` → `ムㇴ` instead of `ムン`. Defaults to `false`.
+    pub use_small_n: bool,
 }
 
 mod util;
@@ -51,6 +75,7 @@ pub use detection::detect;
 pub use conversion::cyrillic::{convert_cyrl_to_latn, convert_latn_to_cyrl};
 pub use conversion::katakana::{
     convert_kana_to_latn, convert_kana_to_latn_with_options, convert_latn_to_kana,
+    convert_latn_to_kana_with_options,
 };
 
 pub fn convert_cyrl_to_kana(cyrl: &str) -> String {

--- a/tests/conversion.rs
+++ b/tests/conversion.rs
@@ -4,10 +4,49 @@ use serde::{Deserialize, Serialize};
 
 const TEST_CASES_JSON: &str = include_str!("./cases/test_cases.json");
 const ROBUSTNESS_JSON: &str = include_str!("./cases/robustness.json");
+const OPTIONS_CATALOG_JSON: &str = include_str!("./cases/options.schema.json");
 
 lazy_static! {
     static ref CASES: Vec<Case> = serde_json::from_str(TEST_CASES_JSON).unwrap();
     static ref ROBUSTNESS: Vec<RobustnessCase> = serde_json::from_str(ROBUSTNESS_JSON).unwrap();
+    static ref OPTIONS_CATALOG: OptionCatalog =
+        serde_json::from_str(OPTIONS_CATALOG_JSON).unwrap();
+}
+
+/// The shared canonical option catalog (`options.schema.json`).
+#[derive(Debug, Deserialize)]
+struct OptionCatalog {
+    options: Vec<OptionSpecMeta>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OptionSpecMeta {
+    key: String,
+}
+
+/// Canonical camelCase keys of the options ainconv-rs implements. Kept in sync
+/// with [`ConversionOptions`]; the parity test below asserts this equals the
+/// shared catalog so an option added in any language fails this build until
+/// Rust implements it too.
+const SUPPORTED_OPTIONS: &[&str] = &[
+    "ellipsisToAscii",
+    "useWi",
+    "useWe",
+    "useWo",
+    "useSmallI",
+    "useSmallU",
+    "useSmallN",
+];
+
+#[test]
+fn test_option_catalog_parity() {
+    use std::collections::BTreeSet;
+    let catalog: BTreeSet<&str> = OPTIONS_CATALOG.options.iter().map(|o| o.key.as_str()).collect();
+    let supported: BTreeSet<&str> = SUPPORTED_OPTIONS.iter().copied().collect();
+    assert_eq!(
+        supported, catalog,
+        "ainconv-rs option set drifted from the shared options.schema.json catalog"
+    );
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -19,6 +58,52 @@ struct Case {
     syllables: Vec<String>,
     #[serde(rename = "latnLossy")]
     latn_lossy: String,
+    #[serde(default)]
+    variants: Vec<Variant>,
+}
+
+/// A conversion-options scenario sharing a base case's input. Output fields are
+/// optional: only the ones present are asserted, so a variant can target a
+/// single direction. Option keys are camelCase to match the shared JSON.
+#[derive(Debug, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct OptionsSpec {
+    #[serde(default)]
+    ellipsis_to_ascii: bool,
+    #[serde(default)]
+    use_wi: bool,
+    #[serde(default)]
+    use_we: bool,
+    #[serde(default)]
+    use_wo: bool,
+    #[serde(default)]
+    use_small_i: bool,
+    #[serde(default)]
+    use_small_u: bool,
+    #[serde(default)]
+    use_small_n: bool,
+}
+
+impl OptionsSpec {
+    fn to_options(&self) -> ConversionOptions {
+        ConversionOptions {
+            ellipsis_to_ascii: self.ellipsis_to_ascii,
+            use_wi: self.use_wi,
+            use_we: self.use_we,
+            use_wo: self.use_wo,
+            use_small_i: self.use_small_i,
+            use_small_u: self.use_small_u,
+            use_small_n: self.use_small_n,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Variant {
+    options: OptionsSpec,
+    kana: Option<String>,
+    #[serde(rename = "latnLossy")]
+    latn_lossy: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -57,6 +142,41 @@ fn test_convert_latn_to_kana() {
             _ => (),
         }
     }
+}
+
+/// Exercises the shared `variants` blocks: each variant reuses its base case's
+/// input but applies conversion options and overrides the expected output.
+#[test]
+fn test_conversion_options_variants() {
+    let mut checked = 0;
+    for case in CASES.iter() {
+        for variant in case.variants.iter() {
+            let options = variant.options.to_options();
+
+            if let Some(expected_kana) = &variant.kana {
+                assert_eq!(
+                    convert_latn_to_kana_with_options(&case.latn, &options),
+                    *expected_kana,
+                    "latn->kana variant {:?} for {:?}",
+                    variant.options,
+                    case.latn
+                );
+                checked += 1;
+            }
+
+            if let Some(expected_latn) = &variant.latn_lossy {
+                assert_eq!(
+                    convert_kana_to_latn_with_options(&case.kana, &options),
+                    *expected_latn,
+                    "kana->latn variant {:?} for {:?}",
+                    variant.options,
+                    case.kana
+                );
+                checked += 1;
+            }
+        }
+    }
+    assert!(checked > 0, "no option variants were exercised");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds Katakana **variant options** for `latn→kana`, bringing ainconv-rs to parity with the Python port's option set, plus the shared-test harness that enforces cross-language parity.

- `ConversionOptions` gains `use_wi/use_we/use_wo/use_small_i/use_small_u/use_small_n`; new `convert_latn_to_kana_with_options`. Defaults reproduce current behaviour (compact variant kana spelled out), so nothing changes for existing callers.
- `tests/conversion.rs`: runs the shared `variants` cases and a **parity test** asserting the Rust option set equals the shared `options.schema.json` catalog (drift in any language turns this red).
- Bumps the `ainconv-tests` submodule to add the catalog + variants.

### Scope note
This **stacks on #9** (ellipsis option) — base is `feat/ellipsis-ascii-option`; retarget to `master` once #9 merges.

The submodule is pinned at the catalog-on-`1d18bd7` base (22 cases) deliberately: bumping to `ainconv-tests` `main` (34 cases) surfaces 4 **pre-existing, unrelated** conversion gaps (long vowels `ônâ`, the `iyayiraykere↔iyairaykere` ambiguity, `kuni p` spacing). Syncing to the latest shared cases + fixing those is a separate PR. The canonical catalog itself is proposed for `ainconv-tests` `main` in a companion PR.

Tests: `cargo test` — 29 pass (14 unit + 6 integration + 9 doctests).