### PR TITLE
docs: point orthography catalogue to shared ainconv-tests

### DIFF
--- a/docs/orthography.md
+++ b/docs/orthography.md
@@ -1,0 +1,9 @@
+# Ainu Orthographic Variation — Catalogue (moved)
+
+This catalogue is implementation-agnostic and lives in the shared
+cross-implementation repo, alongside the `options.schema.json` it maps to:
+
+➡️ **https://github.com/mkpoli/ainconv-tests/blob/main/orthography.md**
+
+It covers all ports (ainconv / ainconv-py / ainconv-rs), so it belongs in
+`ainconv-tests` rather than in this single implementation.


### PR DESCRIPTION
Replaces #10. The Ainu orthographic variation catalogue is implementation-agnostic
(it surveys Ainu orthography and maps each issue to converter behaviour / the
shared `options.schema.json`), so it now lives in the shared cross-implementation
repo **mkpoli/ainconv-tests** rather than in this single Rust implementation:

➡️ https://github.com/mkpoli/ainconv-tests/blob/main/orthography.md

This PR just leaves a small pointer stub at `docs/orthography.md` so anyone
looking here is redirected.